### PR TITLE
🎮 Adiciona GameServerController com rotas REST

### DIFF
--- a/backend/src/main/java/com/app/guimscore/dto/GameServerDto.java
+++ b/backend/src/main/java/com/app/guimscore/dto/GameServerDto.java
@@ -15,6 +15,15 @@ public class GameServerDto {
     private Date dateAt;
     private UserModel user;
 
+    public GameServerDto(String nameServer, String description) {
+        this.nameServer = nameServer;
+        this.description = description;
+    }
+
+    public GameServerDto() {
+
+    }
+
     public UUID getUuid() {
         return uuid;
     }

--- a/backend/src/main/java/com/app/guimscore/infra/security/JwtService.java
+++ b/backend/src/main/java/com/app/guimscore/infra/security/JwtService.java
@@ -6,13 +6,16 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.UUID;
 
 @Service
 public class JwtService {
@@ -31,6 +34,7 @@ public class JwtService {
                     .withExpiresAt(this.generateExpires())
                     .withIssuer("guymdx-fg")
                     .withSubject(userModel.getName())
+                    .withClaim("userId", userModel.getUuid().toString())
                     .sign(algorithm);
 
         } catch (JWTCreationException exception) {
@@ -52,6 +56,23 @@ public class JwtService {
         } catch (JWTVerificationException exception) {
             throw new RuntimeException("Não foi possivel validar o token");
         }
+    }
+
+    public UUID getUserIdByToken(Authentication authentication) {
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new RuntimeException("Usuário não autenticado");
+        }
+
+        if (authentication.getPrincipal() instanceof String jwtToken) {
+            DecodedJWT jwt = JWT.decode(jwtToken);
+            jwt.getClaim("userId").asString();
+            return UUID.fromString(jwt.getClaim("userId").asString());
+
+        } else {
+            return UUID.fromString(authentication.getName());
+        }
+
     }
 
     private Instant generateExpires() {

--- a/backend/src/main/java/com/app/guimscore/service/DataService.java
+++ b/backend/src/main/java/com/app/guimscore/service/DataService.java
@@ -1,7 +1,6 @@
 package com.app.guimscore.service;
 
 import com.app.guimscore.dto.DataDto;
-import com.app.guimscore.dto.GameServerDto;
 import com.app.guimscore.model.DataModel;
 import com.app.guimscore.model.GameServerModel;
 import com.app.guimscore.model.UserModel;
@@ -140,7 +139,7 @@ public class DataService {
     void updateData(UUID dataId, UUID userId, UUID gameServerId, DataDto dataDto) {
         try {
 
-            DataModel dataModel = this.validateAccessToData(dataId, userId, gameServerId);
+            this.validateAccessToData(dataId, userId, gameServerId);
 
             DataModel newData = new DataModel();
 

--- a/backend/src/main/java/com/app/guimscore/service/GameServerService.java
+++ b/backend/src/main/java/com/app/guimscore/service/GameServerService.java
@@ -5,16 +5,17 @@ import com.app.guimscore.model.GameServerModel;
 import com.app.guimscore.model.UserModel;
 import com.app.guimscore.model.exceptions.ForbiddenException;
 import com.app.guimscore.model.exceptions.NotFoundException;
-import com.app.guimscore.model.roles.UserRole;
 import com.app.guimscore.repository.GameServerRepository;
 import com.app.guimscore.repository.UserRepository;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@Service
 public class GameServerService {
 
     @Autowired

--- a/backend/src/main/java/com/app/guimscore/service/GameServerService.java
+++ b/backend/src/main/java/com/app/guimscore/service/GameServerService.java
@@ -85,21 +85,19 @@ public class GameServerService {
         }
     }
 
-    void deleteGameServer(UUID userId, UUID gameServerId) {
+    public void deleteGameServer(UUID userId, UUID gameServerId) {
         GameServerModel gameServerModel = this.isGameServerExistAndAuthorized(userId, gameServerId);
 
         gameServerRepository.delete(gameServerModel);
 
     }
 
-    void updateGameServer(UUID userId, UUID gameServerId, GameServerDto gameServerDto) {
+    public void updateGameServer(UUID userId, UUID gameServerId, GameServerDto gameServerDto) {
         GameServerModel gameServerModel = this.isGameServerExistAndAuthorized(userId, gameServerId);
-
-        GameServerModel gameServerModelSave = new GameServerModel();
 
         BeanUtils.copyProperties(gameServerDto, gameServerModel);
 
-        this.gameServerRepository.save(gameServerModelSave);
+        this.gameServerRepository.save(gameServerModel);
     }
 
     private GameServerModel isGameServerExistAndAuthorized(UUID userId, UUID gameServerId) {

--- a/backend/src/main/java/com/app/guimscore/service/ListItem.java
+++ b/backend/src/main/java/com/app/guimscore/service/ListItem.java
@@ -91,7 +91,7 @@ public class ListItem {
 
         this.validateUserAdmin(gameServerId, userId);
 
-        ItemsModel itemsModel = new ItemsModel();
+        ItemsModel itemsModel = itemsRepository.findById(listId).get();
 
         BeanUtils.copyProperties(listItemDto, itemsModel);
 
@@ -215,7 +215,7 @@ public class ListItem {
             throw new NotFoundException("GameServer inexistente");
         }
 
-        if (gameServerModelOptional.get().getUser().getUuid().equals(userId)) {
+        if (!gameServerModelOptional.get().getUser().getUuid().equals(userId)) {
             throw new ForbiddenException("Acesso negado");
         }
     }

--- a/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
+++ b/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
@@ -6,9 +6,6 @@ import com.app.guimscore.service.GameServerService;
 import com.app.guimscore.view.model.GameServerDetailsDto;
 import com.app.guimscore.view.model.GameServerReqDto;
 import com.app.guimscore.view.model.GameServerResDto;
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.interfaces.DecodedJWT;
-import jakarta.websocket.server.PathParam;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -56,7 +53,7 @@ public class GameServerController {
     }
 
     @GetMapping("{id}")
-    ResponseEntity<GameServerDetailsDto> findGameServerDetails(Authentication authentication, @PathParam("id") UUID gameId) {
+    ResponseEntity<GameServerDetailsDto> findGameServerDetails(Authentication authentication, @PathVariable("id") UUID gameId) {
 
         UUID userId = this.jwtService.getUserIdByToken(authentication);
 
@@ -68,6 +65,14 @@ public class GameServerController {
 
     }
 
+    @DeleteMapping("{id}")
+    ResponseEntity<String> deleteGameServer(Authentication authentication, @PathVariable("id") UUID gameServerId) {
 
+        UUID userId = this.jwtService.getUserIdByToken(authentication);
+
+        this.gameServerService.deleteGameServer(userId, gameServerId);
+
+        return ResponseEntity.ok("GameServer deletado com sucesso");
+    }
 
 }

--- a/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
+++ b/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
@@ -3,10 +3,12 @@ package com.app.guimscore.view.controller;
 import com.app.guimscore.dto.GameServerDto;
 import com.app.guimscore.infra.security.JwtService;
 import com.app.guimscore.service.GameServerService;
+import com.app.guimscore.view.model.GameServerDetailsDto;
 import com.app.guimscore.view.model.GameServerReqDto;
 import com.app.guimscore.view.model.GameServerResDto;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import jakarta.websocket.server.PathParam;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,6 +54,20 @@ public class GameServerController {
         return ResponseEntity.ok(gameServerResDtoList);
 
     }
+
+    @GetMapping("{id}")
+    ResponseEntity<GameServerDetailsDto> findGameServerDetails(Authentication authentication, @PathParam("id") UUID gameId) {
+
+        UUID userId = this.jwtService.getUserIdByToken(authentication);
+
+        GameServerDto gameServerDto = this.gameServerService.findGameServerById(userId, gameId);
+
+        GameServerDetailsDto gameServerDetailsDto = new GameServerDetailsDto(gameServerDto.getUuid(), gameServerDto.getNameServer(), gameServerDto.getDescription(), gameServerDto.getDateAt(), null, null);
+
+        return ResponseEntity.ok(gameServerDetailsDto);
+
+    }
+
 
 
 }

--- a/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
+++ b/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
@@ -75,4 +75,17 @@ public class GameServerController {
         return ResponseEntity.ok("GameServer deletado com sucesso");
     }
 
+    @PutMapping("{id}")
+    ResponseEntity<String> updateGameServer(Authentication authentication, @RequestBody GameServerReqDto gameServerReqDto, @PathVariable("id") UUID gameServerId) {
+
+        UUID userId = this.jwtService.getUserIdByToken(authentication);
+
+        GameServerDto gameServerDto = new GameServerDto(gameServerReqDto.nameServer(), gameServerReqDto.description());
+
+        this.gameServerService.updateGameServer(userId, gameServerId, gameServerDto);
+
+        return ResponseEntity.ok("GameServer autalizado com sucesso");
+
+    }
+
 }

--- a/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
+++ b/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
@@ -1,0 +1,42 @@
+package com.app.guimscore.view.controller;
+
+import com.app.guimscore.dto.GameServerDto;
+import com.app.guimscore.infra.security.JwtService;
+import com.app.guimscore.service.GameServerService;
+import com.app.guimscore.view.model.GameServerReqDto;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("game-server")
+public class GameServerController {
+
+    @Autowired
+    private GameServerService gameServerService;
+    @Autowired
+    private JwtService jwtService;
+
+    @PostMapping()
+    ResponseEntity<String> createGameServer(@RequestBody GameServerReqDto gameServerReqDto, Authentication authentication) {
+
+        GameServerDto gameServerDto = new GameServerDto(gameServerReqDto.nameServer(), gameServerReqDto.description());
+
+        UUID userId = jwtService.getUserIdByToken(authentication);
+
+        this.gameServerService.createGameServer(gameServerDto, userId);
+
+        return ResponseEntity.ok("GameServer criado com sucesso");
+
+    }
+
+
+}

--- a/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
+++ b/backend/src/main/java/com/app/guimscore/view/controller/GameServerController.java
@@ -4,16 +4,16 @@ import com.app.guimscore.dto.GameServerDto;
 import com.app.guimscore.infra.security.JwtService;
 import com.app.guimscore.service.GameServerService;
 import com.app.guimscore.view.model.GameServerReqDto;
+import com.app.guimscore.view.model.GameServerResDto;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -34,7 +34,22 @@ public class GameServerController {
 
         this.gameServerService.createGameServer(gameServerDto, userId);
 
-        return ResponseEntity.ok("GameServer criado com sucesso");
+        return ResponseEntity.status(HttpStatus.CREATED).body("GameServer criado com sucesso");
+
+    }
+
+    @GetMapping()
+    ResponseEntity<List<GameServerResDto>> findAllGameServer(Authentication authentication) {
+
+        UUID userId = this.jwtService.getUserIdByToken(authentication);
+
+        List<GameServerDto> gameServerDtoList = this.gameServerService.findAllGameServers(userId);
+
+        List<GameServerResDto> gameServerResDtoList = gameServerDtoList.stream()
+                .map(game -> new GameServerResDto(game.getUuid(), game.getNameServer(), game.getDescription(), game.getDateAt()))
+                .toList();
+
+        return ResponseEntity.ok(gameServerResDtoList);
 
     }
 

--- a/backend/src/test/java/com/app/guimscore/service/GameServerServiceTest.java
+++ b/backend/src/test/java/com/app/guimscore/service/GameServerServiceTest.java
@@ -1,6 +1,7 @@
 package com.app.guimscore.service;
 
 import com.app.guimscore.dto.GameServerDto;
+import com.app.guimscore.model.DataModel;
 import com.app.guimscore.model.GameServerModel;
 import com.app.guimscore.model.UserModel;
 import com.app.guimscore.model.exceptions.ForbiddenException;
@@ -167,6 +168,8 @@ public class GameServerServiceTest {
 
         gameServerService.deleteGameServer(uuid, uuid);
 
+        Mockito.verify(gameServerRepository, Mockito.times(1)).delete(Mockito.any(GameServerModel.class));
+
     }
 
     @DisplayName("should update a gameServer")
@@ -185,6 +188,8 @@ public class GameServerServiceTest {
         Mockito.when(gameServerRepository.findById(Mockito.any(UUID.class))).thenReturn(Optional.of(gameServerModel));
 
         gameServerService.updateGameServer(uuid, uuid, gameServerDto);
+
+        Mockito.verify(gameServerRepository, Mockito.times(1)).save(Mockito.any(GameServerModel.class));
     }
 
 }


### PR DESCRIPTION
# 🎮 Implementação do `GameServerController`

Este PR adiciona o controlador REST responsável por gerenciar as operações relacionadas ao recurso `GameServer`. Com ele, é possível:

- Criar novos servidores de jogo
- Listar todos os servidores de um usuário
- Buscar um servidor específico
- Atualizar dados de um servidor
- Excluir servidores

Também foram criadas validações completas para garantir que apenas usuários autenticados e proprietários dos servidores possam realizar as operações.

---

## ✅ Funcionalidades Implementadas

- [x] Rota POST `/game-servers` – Cria um novo servidor
- [x] Rota GET `/game-servers` – Lista todos os servidores do usuário autenticado
- [x] Rota GET `/game-servers/{id}` – Retorna detalhes de um servidor específico
- [x] Rota PUT `/game-servers/{id}` – Atualiza informações do servidor
- [x] Rota DELETE `/game-servers/{id}` – Remove um servidor
---

